### PR TITLE
Add ForecastRepository  and dependency wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ AGENTS.md
 CLAUDE.md
 .claude
 *.db
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?
 **Query by month or month range:**
 ```bash
 # Single month
-curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&months=2024-01"
+curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&months=2025-09"
 
 # Month range
-curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&month_range=2024-01:2024-06"
+curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&month_range=2025-08:2025-12"
 ```
 
 **Choose specific metrics (MAP, confidence intervals, probabilities):**
@@ -107,7 +107,7 @@ curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?
 curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&metrics=map&metrics=ci_50_low&metrics=ci_50_high&metrics=ci_90_low&metrics=ci_90_high&metrics=ci_99_low&metrics=ci_99_high&metrics=prob_100&metrics=prob_1000"
 
 # Just MAP and 90% confidence interval
-curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&months=2024-01&metrics=map&metrics=ci_90_low&metrics=ci_90_high"
+curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&months=2025-09&metrics=map&metrics=ci_90_low&metrics=ci_90_high"
 ```
 
 ## Data Storage

--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?
 curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&months=2025-09&metrics=map&metrics=ci_90_low&metrics=ci_90_high"
 ```
 
+**Filter by metric thresholds (e.g. MAP > 50):**
+```bash
+curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&metric_filters=map>50"
+
+# Combine multiple filters
+curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&metric_filters=map>50&metric_filters=prob_1000>=0.1"
+```
+
 ## Data Storage
 
 The API supports these data storage modes:

--- a/README.md
+++ b/README.md
@@ -80,15 +80,34 @@ Query parameters:
 - `metrics`: Specific metrics to return
 - `format`: Response format (json or ndjson)
 
-Example:
+Examples:
 
-```bash
-curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&months=2024-01&metrics=map&metrics=ci_90_low&metrics=ci_90_high"
-```
-or:
-
+**Query by country (all cells in a country):**
 ```bash
 curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074"
+```
+
+**Query by specific grid cell IDs:**
+```bash
+curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?grid_ids=12001001&grid_ids=12001002"
+```
+
+**Query by month or month range:**
+```bash
+# Single month
+curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&months=2024-01"
+
+# Month range
+curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&month_range=2024-01:2024-06"
+```
+
+**Choose specific metrics (MAP, confidence intervals, probabilities):**
+```bash
+# All confidence intervals and probabilities
+curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&metrics=map&metrics=ci_50_low&metrics=ci_50_high&metrics=ci_90_low&metrics=ci_90_high&metrics=ci_99_low&metrics=ci_99_high&metrics=prob_100&metrics=prob_1000"
+
+# Just MAP and 90% confidence interval
+curl -H "X-API-Key: your-local-api-key" "http://localhost:8000/api/v1/forecasts?country=074&months=2024-01&metrics=map&metrics=ci_90_low&metrics=ci_90_high"
 ```
 
 ## Data Storage
@@ -113,13 +132,6 @@ The API supports these data storage modes:
   - `MODE=append` appends instead of replacing.
 - Use `make db-clean` (or `python scripts/load_parquet_to_db.py --reset-db`) when you want to remove the SQLite file and start fresh.
 - When refreshing data, re-run `make db-load MODE=replace` (default) or `MODE=append` depending on your workflow.
-
-### Cloud Storage (Production)
-
-- Set `USE_LOCAL_DATA=false` and/or `DATA_BACKEND=cloud`.
-- Configure S3 credentials in `.env` using `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (or rely on the default credential chain inside your deployment environment). For quick demos you can export the shared sandbox keys shown in the quick-start section.
-- Point `CLOUD_BUCKET_NAME` at the bucket that stores parquet files and use either `CLOUD_DATA_KEY` for a single parquet object (for example `api_ready/forecasts.parquet`) or `CLOUD_DATA_PREFIX` to load every parquet under a folder.
-- The loader downloads parquet objects directly from S3 using `boto3`; ensure the IAM role or user has `s3:ListBucket` and `s3:GetObject` permissions for the configured bucket.
 
 ## Development
 

--- a/app/api/routes/forecasts.py
+++ b/app/api/routes/forecasts.py
@@ -28,6 +28,10 @@ async def get_forecasts(
         None,
         description="Specific metrics to return (defaults to all metrics)",
     ),
+    metric_filters: Optional[List[str]] = Query(
+        None,
+        description="Numeric metric filters (e.g. map>50, prob_1000<=0.1)",
+    ),
     format: str = Query("json", description="Response format: json or ndjson"),
     _: bool = Depends(verify_api_key),
     service: ForecastService = Depends(get_forecast_service),
@@ -42,6 +46,7 @@ async def get_forecasts(
     - **months**: List of specific months (can be repeated: ?months=2024-01&months=2024-02)
     - **month_range**: Range of months (e.g., "2024-01:2024-06")
     - **metrics**: Specific metrics to include (if not specified, returns all 13 metrics)
+    - **metric_filters**: Numeric filters expressed as metric/operator/value (e.g., `map>50`)
     - **format**: Response format ("json" or "ndjson" for streaming)
 
     ## Available Metrics
@@ -68,6 +73,11 @@ async def get_forecasts(
     ```
     GET /api/v1/forecasts?grid_ids=1&grid_ids=2&month_range=2024-01:2024-06&metrics=map&metrics=ci_90_low&metrics=ci_90_high
     ```
+
+    Filter by metric threshold (MAP greater than 50):
+    ```
+    GET /api/v1/forecasts?country=800&metric_filters=map>50
+    ```
     """
     try:
         query = ForecastQuery(
@@ -76,6 +86,7 @@ async def get_forecasts(
             months=months,
             month_range=month_range,
             metrics=metrics,
+            metric_filters=metric_filters,
             format=format,
         )
 
@@ -110,6 +121,10 @@ async def get_forecast_summary(
     grid_ids: Optional[List[int]] = Query(None, description="Filter by grid cell IDs"),
     months: Optional[List[str]] = Query(None, description="Filter by months"),
     month_range: Optional[str] = Query(None, description="Month range"),
+    metric_filters: Optional[List[str]] = Query(
+        None,
+        description="Numeric metric filters (e.g. map>50, prob_1000<=0.1)",
+    ),
     _: bool = Depends(verify_api_key),
     service: ForecastService = Depends(get_forecast_service),
 ):
@@ -125,7 +140,11 @@ async def get_forecast_summary(
     """
     try:
         query = ForecastQuery(
-            country=country, grid_ids=grid_ids, months=months, month_range=month_range
+            country=country,
+            grid_ids=grid_ids,
+            months=months,
+            month_range=month_range,
+            metric_filters=metric_filters,
         )
 
         forecasts = service.get_forecasts(query)

--- a/app/di.py
+++ b/app/di.py
@@ -1,0 +1,27 @@
+"""Dependency wiring for FastAPI routes."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from fastapi import Depends
+
+from app.domain.repositories import ForecastRepository
+from app.services.data_loader import ParquetForecastRepository
+from app.services.forecast_service import ForecastService
+
+
+@lru_cache
+def get_forecast_repository() -> ForecastRepository:
+    """Return the parquet-backed repository (cached per process)."""
+    return ParquetForecastRepository()
+
+
+def get_forecast_service(
+    repository: ForecastRepository = Depends(get_forecast_repository),
+) -> ForecastService:
+    """Return the forecast service wired with the repository."""
+    return ForecastService(repository=repository)
+
+
+__all__ = ["get_forecast_repository", "get_forecast_service"]

--- a/app/domain/repositories.py
+++ b/app/domain/repositories.py
@@ -1,0 +1,31 @@
+"""Domain-level repository protocols."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Protocol
+
+from app.models.forecast import GridCellForecast, MetricName
+
+
+class ForecastRepository(Protocol):
+    """Abstraction for retrieving forecast data.
+
+    Concrete implementations may load data from parquet files,
+    databases, or remote services. Application services should
+    depend on this protocol instead of concrete data loaders.
+    """
+
+    def get_forecasts(
+        self,
+        country: Optional[str] = None,
+        grid_ids: Optional[List[int]] = None,
+        months: Optional[List[str]] = None,
+        metrics: Optional[List[MetricName]] = None,
+    ) -> List[GridCellForecast]:
+        """Return forecasts filtered by the provided criteria."""
+
+    def get_available_months(self) -> List[Dict[str, Any]]:
+        """Return summary metadata for available forecast months."""
+
+    def get_grid_cells(self, country: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Return metadata for unique grid cells, optionally filtered by country."""

--- a/app/domain/repositories.py
+++ b/app/domain/repositories.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Protocol
 
-from app.models.forecast import GridCellForecast, MetricName
+from app.models.forecast import GridCellForecast, MetricConstraint, MetricName
 
 
 class ForecastRepository(Protocol):
@@ -21,6 +21,7 @@ class ForecastRepository(Protocol):
         grid_ids: Optional[List[int]] = None,
         months: Optional[List[str]] = None,
         metrics: Optional[List[MetricName]] = None,
+        metric_constraints: Optional[List[MetricConstraint]] = None,
     ) -> List[GridCellForecast]:
         """Return forecasts filtered by the provided criteria."""
 

--- a/app/services/data_loader.py
+++ b/app/services/data_loader.py
@@ -1,302 +1,65 @@
-"""Data loading service for forecast data from multiple backends.
+"""Parquet-backed implementation of the forecast repository."""
 
-This module handles loading forecast data from various storage backends
-including SQLite databases, parquet files, and cloud storage (S3). It provides
-a unified interface for data access with caching support for performance.
-"""
+from __future__ import annotations
 
-import io
 import logging
-import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
 from cachetools import TTLCache
 
-try:
-    import boto3
-    from botocore.exceptions import BotoCoreError, ClientError
-except ModuleNotFoundError:  # pragma: no cover - boto3 optional for local workflows
-    boto3 = None
-    BotoCoreError = ClientError = Exception
-
 from app.core.config import settings
+from app.domain.repositories import ForecastRepository
 from app.models.forecast import ALL_METRIC_NAMES, ForecastMetrics, GridCellForecast, MetricName
 from app.services.data_initializer import ensure_local_data_ready
-from app.services.db_utils import sqlite_path_from_url
-from app.services.sample_data import FORECAST_COLUMNS, generate_sample_forecasts
+from app.services.sample_data import generate_sample_forecasts
 
 logger = logging.getLogger(__name__)
 
 
-class DataLoader:
-    """Main data loading class supporting multiple storage backends.
+class ParquetForecastRepository(ForecastRepository):
+    """Load forecasts from local parquet files with light caching."""
 
-    Provides unified data access for forecast data stored in SQLite databases,
-    parquet files, or cloud storage. Includes caching for performance optimization
-    and automatic initialization of the appropriate storage backend.
-
-    Attributes:
-        cache: TTL cache for storing loaded data.
-        data_path: Path to local data directory.
-        backend: Storage backend type (database/parquet/cloud).
-        _data: Cached DataFrame of forecast data.
-        _s3_client: AWS S3 client for cloud storage access.
-        _db_path: Path to SQLite database file.
-    """
-
-    def __init__(self):
-        """Initialize data loader with configured backend."""
+    def __init__(self, data_path: Optional[str | Path] = None):
         self.cache = TTLCache(maxsize=settings.cache_max_size, ttl=settings.cache_ttl_seconds)
-        self.data_path = Path(settings.data_path)
-        self.backend = settings.data_backend
-        self._data: Optional[pd.DataFrame] = None
-        self._s3_client = None
-        self._db_path: Optional[Path] = None
-
-        if self.backend == "cloud" and self._should_use_sample_backend():
-            logger.warning(
-                "Falling back to sample data because USE_LOCAL_DATA is true or AWS credentials are missing."
-            )
-            self.backend = "parquet"
-            self._ensure_local_data_exists()
-            ensure_local_data_ready(prompt_user=False)
-
-        if self.backend == "parquet":
-            self._ensure_local_data_exists()
-        elif self.backend == "database":
-            self._init_database()
-        elif self.backend == "cloud":
-            self._init_cloud_storage()
-        else:  # pragma: no cover - guard for unexpected configuration
-            raise ValueError(f"Unsupported data backend: {self.backend}")
-
-    @staticmethod
-    def _is_blank(value: Optional[str]) -> bool:
-        """Return True when a string value is None or empty after stripping."""
-
-        if value is None:
-            return True
-
-        if isinstance(value, str) and not value.strip():
-            return True
-
-        return False
-
-    def _should_use_sample_backend(self) -> bool:
-        """Determine whether to bypass the cloud backend and use samples instead."""
-
-        if settings.use_local_data:
-            return True
-
-        if self._is_blank(settings.aws_access_key_id) or self._is_blank(
-            settings.aws_secret_access_key
-        ):
-            return True
-
-        return False
-
-    def _ensure_local_data_exists(self):
-        """Ensure local data directory exists."""
+        self.data_path = Path(data_path or settings.data_path)
         self.data_path.mkdir(parents=True, exist_ok=True)
 
-    def _init_database(self):
-        """Prepare SQLite database configuration."""
-
-        try:
-            self._db_path = sqlite_path_from_url(settings.database_url)
-        except ValueError as exc:
-            raise ValueError(f"Invalid DATABASE_URL '{settings.database_url}': {exc}") from exc
-
-        if not self._db_path.parent.exists():
-            self._db_path.parent.mkdir(parents=True, exist_ok=True)
-
-        logger.info("Configured SQLite database at %s", self._db_path)
-
-    def _init_cloud_storage(self):
-        """Initialize cloud storage connection."""
-        if not boto3:
-            raise ImportError(
-                "boto3 is required for cloud data loading but is not installed. "
-                "Install dependencies with `make install` after updating requirements."
-            )
-
-        if not settings.cloud_bucket_name:
-            raise ValueError("CLOUD_BUCKET_NAME must be set when USE_LOCAL_DATA=false")
-
-        session = boto3.session.Session(
-            aws_access_key_id=settings.aws_access_key_id,
-            aws_secret_access_key=settings.aws_secret_access_key,
-            region_name=settings.cloud_bucket_region,
-        )
-
-        self._s3_client = session.client("s3")
-
     def _load_data(self) -> pd.DataFrame:
-        """Load data from storage (local or cloud)."""
-        cache_key = f"all_data::{self.backend}"
+        cache_key = f"parquet::{self.data_path.resolve()}"
 
         if cache_key in self.cache:
-            logger.debug("Returning cached data")
             return self.cache[cache_key]
 
-        if self.backend == "parquet":
-            df = self._load_local_data()
-        elif self.backend == "database":
-            df = self._load_database_data()
-        elif self.backend == "cloud":
-            df = self._load_cloud_data()
-        else:  # pragma: no cover - guard for unsupported configuration
-            raise ValueError(f"Unsupported data backend: {self.backend}")
+        parquet_files = list(self.data_path.glob("*.parquet"))
+
+        if not parquet_files:
+            logger.info("No parquet files found in %s; ensuring sample data exists", self.data_path)
+            ensure_local_data_ready(prompt_user=False)
+            parquet_files = list(self.data_path.glob("*.parquet"))
+
+        frames: List[pd.DataFrame] = []
+        for file in parquet_files:
+            try:
+                frames.append(pd.read_parquet(file))
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Failed to load %s: %s", file, exc)
+
+        if not frames:
+            logger.warning("Falling back to generated sample data")
+            df = self._create_sample_data()
+        else:
+            df = pd.concat(frames, ignore_index=True)
 
         self.cache[cache_key] = df
         return df
 
-    def _load_local_data(self) -> pd.DataFrame:
-        """Load data from local parquet files"""
-        parquet_files = list(self.data_path.glob("*.parquet"))
-
-        if not parquet_files:
-            logger.warning("No parquet files found in %s", self.data_path)
-            ensure_local_data_ready(prompt_user=False)
-            parquet_files = list(self.data_path.glob("*.parquet"))
-
-        if not parquet_files:
-            logger.error(
-                "Unable to create sample data automatically. Returning empty DataFrame for safety."
-            )
-            return pd.DataFrame(columns=FORECAST_COLUMNS)
-
-        dfs = []
-        for file in parquet_files:
-            try:
-                df = pd.read_parquet(file)
-                dfs.append(df)
-            except Exception as e:
-                logger.error(f"Error loading {file}: {e}")
-
-        if dfs:
-            return pd.concat(dfs, ignore_index=True)
-        else:
-            return self._create_sample_data()
-
-    def _load_database_data(self) -> pd.DataFrame:
-        """Load data from a SQLite database"""
-
-        if not self._db_path:
-            logger.error("Database path is not configured; falling back to empty DataFrame")
-            return pd.DataFrame(columns=FORECAST_COLUMNS)
-
-        if not self._db_path.exists():
-            logger.warning(
-                "SQLite database %s not found. Run `python scripts/load_parquet_to_db.py` "
-                "or `make db-load` to populate it.",
-                self._db_path,
-            )
-            return pd.DataFrame(columns=FORECAST_COLUMNS)
-
-        try:
-            with sqlite3.connect(self._db_path) as conn:
-                df = pd.read_sql_query("SELECT * FROM forecasts", conn)
-        except sqlite3.OperationalError as exc:
-            logger.error("Failed to read forecasts table from %s: %s", self._db_path, exc)
-            return pd.DataFrame(columns=FORECAST_COLUMNS)
-
-        missing_columns = [col for col in FORECAST_COLUMNS if col not in df.columns]
-        if missing_columns:
-            logger.error(
-                "Database %s is missing expected columns: %s",
-                self._db_path,
-                ", ".join(missing_columns),
-            )
-            return pd.DataFrame(columns=FORECAST_COLUMNS)
-
-        df = df[FORECAST_COLUMNS]
-        return df
-
-    def _load_cloud_data(self) -> pd.DataFrame:
-        """Load data from cloud storage"""
-        if not self._s3_client:
-            logger.error("S3 client is not initialized; falling back to sample data")
-            return self._create_sample_data()
-
-        bucket = settings.cloud_bucket_name
-        object_keys = self._resolve_object_keys(bucket)
-
-        if not object_keys:
-            logger.warning(
-                "No parquet objects found in bucket %s with prefix '%s'",
-                bucket,
-                settings.cloud_data_prefix,
-            )
-            return self._create_sample_data()
-
-        dfs = []
-        for key in object_keys:
-            try:
-                buffer = io.BytesIO()
-                self._s3_client.download_fileobj(bucket, key, buffer)
-                buffer.seek(0)
-                dfs.append(pd.read_parquet(buffer))
-                logger.info("Loaded %s from s3://%s/%s", key, bucket, key)
-            except (ClientError, BotoCoreError) as exc:
-                logger.error("Failed to download %s from bucket %s: %s", key, bucket, exc)
-            except Exception as exc:  # pragma: no cover - defensive guard
-                logger.error("Failed to parse parquet %s in bucket %s: %s", key, bucket, exc)
-
-        if not dfs:
-            logger.error("Unable to load any parquet objects; returning sample data")
-            return self._create_sample_data()
-
-        return pd.concat(dfs, ignore_index=True)
-
-    def _resolve_object_keys(self, bucket: str) -> List[str]:
-        """Collect parquet object keys based on configuration."""
-        if settings.cloud_data_key:
-            return [settings.cloud_data_key]
-
-        prefix = settings.cloud_data_prefix.strip("/") if settings.cloud_data_prefix else ""
-        if prefix and not prefix.endswith("/"):
-            prefix = f"{prefix}/"
-
-        continuation_token = None
-        keys: List[str] = []
-
-        while True:
-            try:
-                list_kwargs = {"Bucket": bucket, "Prefix": prefix}
-                if continuation_token:
-                    list_kwargs["ContinuationToken"] = continuation_token
-
-                response = self._s3_client.list_objects_v2(**list_kwargs)
-            except (ClientError, BotoCoreError) as exc:
-                logger.error("Failed to list objects in bucket %s: %s", bucket, exc)
-                return []
-
-            for obj in response.get("Contents", []):
-                key = obj.get("Key")
-                if key and key.endswith(".parquet"):
-                    keys.append(key)
-
-            if response.get("IsTruncated"):
-                continuation_token = response.get("NextContinuationToken")
-            else:
-                break
-
-        return keys
-
     def _create_sample_data(self) -> pd.DataFrame:
-        """Create sample data for testing"""
-        logger.info("Creating sample forecast data")
-
         df = generate_sample_forecasts()
-
-        # Save sample data for future use
         sample_file = self.data_path / "sample_data.parquet"
         df.to_parquet(sample_file, index=False)
-        logger.info(f"Sample data saved to {sample_file}")
-
+        logger.info("Sample data written to %s", sample_file)
         return df
 
     def get_forecasts(
@@ -306,10 +69,8 @@ class DataLoader:
         months: Optional[List[str]] = None,
         metrics: Optional[List[MetricName]] = None,
     ) -> List[GridCellForecast]:
-        """Get forecasts with optional filters"""
         df = self._load_data()
 
-        # Apply filters
         if country:
             df = df[df["country_id"] == country]
 
@@ -319,36 +80,31 @@ class DataLoader:
         if months:
             df = df[df["month"].isin(months)]
 
-        # Convert to forecast objects
-        forecasts = []
+        selected_metrics = [metric.value for metric in metrics] if metrics else ALL_METRIC_NAMES
+
+        forecasts: List[GridCellForecast] = []
         for _, row in df.iterrows():
-            forecast_dict = row.to_dict()
-
-            # Extract metrics
-            selected_metrics = [metric.value for metric in metrics] if metrics else ALL_METRIC_NAMES
-            metrics_data = {
-                name: forecast_dict[name] for name in selected_metrics if name in forecast_dict
-            }
-
-            forecast = GridCellForecast(
-                grid_id=int(forecast_dict["grid_id"]),
-                latitude=float(forecast_dict["latitude"]),
-                longitude=float(forecast_dict["longitude"]),
-                country_id=forecast_dict["country_id"],
-                admin_1_id=forecast_dict.get("admin_1_id"),
-                admin_2_id=forecast_dict.get("admin_2_id"),
-                month=forecast_dict["month"],
-                metrics=ForecastMetrics(**metrics_data),
+            record = row.to_dict()
+            metrics_data = {name: record[name] for name in selected_metrics if name in record}
+            forecasts.append(
+                GridCellForecast(
+                    grid_id=int(record["grid_id"]),
+                    latitude=float(record["latitude"]),
+                    longitude=float(record["longitude"]),
+                    country_id=str(record["country_id"]),
+                    admin_1_id=record.get("admin_1_id"),
+                    admin_2_id=record.get("admin_2_id"),
+                    month=record["month"],
+                    metrics=ForecastMetrics(**metrics_data),
+                )
             )
-            forecasts.append(forecast)
 
         return forecasts
 
     def get_available_months(self) -> List[Dict[str, Any]]:
-        """Get list of available forecast months"""
         df = self._load_data()
 
-        months_data = []
+        months_data: List[Dict[str, Any]] = []
         for month in df["month"].unique():
             month_df = df[df["month"] == month]
             months_data.append(
@@ -359,35 +115,32 @@ class DataLoader:
                 }
             )
 
-        return sorted(months_data, key=lambda x: x["month"])
+        return sorted(months_data, key=lambda item: item["month"])
 
     def get_grid_cells(self, country: Optional[str] = None) -> List[Dict[str, Any]]:
-        """Get list of available grid cells"""
         df = self._load_data()
 
         if country:
             df = df[df["country_id"] == country]
 
-        # Get unique grid cells
-        grid_cells = (
+        grouped = (
             df.groupby(["grid_id", "latitude", "longitude", "country_id"]).first().reset_index()
         )
 
-        cells_data = []
-        for _, row in grid_cells.iterrows():
-            cells_data.append(
+        cells: List[Dict[str, Any]] = []
+        for _, row in grouped.iterrows():
+            cells.append(
                 {
                     "grid_id": int(row["grid_id"]),
                     "latitude": float(row["latitude"]),
                     "longitude": float(row["longitude"]),
-                    "country_id": row["country_id"],
+                    "country_id": str(row["country_id"]),
                     "admin_1_id": row.get("admin_1_id"),
                     "admin_2_id": row.get("admin_2_id"),
                 }
             )
 
-        return cells_data
+        return cells
 
 
-# Singleton instance
-data_loader = DataLoader()
+__all__ = ["ParquetForecastRepository"]

--- a/app/services/forecast_service.py
+++ b/app/services/forecast_service.py
@@ -57,11 +57,17 @@ class ForecastService:
                 for metric in query.metrics
             ]
 
+        try:
+            metric_constraints = query.parse_metric_filters()
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
+
         forecasts = self.repository.get_forecasts(
             country=query.country,
             grid_ids=query.grid_ids,
             months=months_filter,
             metrics=metrics_filter,
+            metric_constraints=metric_constraints,
         )
 
         logger.info("Retrieved %d forecasts", len(forecasts))

--- a/app/services/forecast_service.py
+++ b/app/services/forecast_service.py
@@ -1,37 +1,23 @@
-"""Core service for forecast data retrieval and processing.
-
-This module provides the main business logic layer for handling forecast
-data operations, including query processing, data filtering, and summary
-generation. It acts as an intermediary between the API routes and the
-data loader.
-"""
+"""Core service for forecast data retrieval and processing."""
 
 import logging
 from datetime import datetime
 from typing import Any, Dict, List
 
+from app.domain.repositories import ForecastRepository
 from app.models.forecast import ForecastQuery, GridCellForecast, MetricName
-from app.services.data_loader import data_loader
 
 logger = logging.getLogger(__name__)
 
 
 class ForecastService:
-    """Main service class for handling forecast operations.
+    """Business logic for querying forecasts."""
 
-    Provides methods for querying, filtering, and summarizing forecast data.
-    Acts as the business logic layer between API endpoints and data storage.
-
-    Attributes:
-        data_loader: Instance of DataLoader for accessing forecast data.
-    """
-
-    def __init__(self):
-        """Initialize the forecast service with data loader."""
-        self.data_loader = data_loader
+    def __init__(self, repository: ForecastRepository):
+        self.repository = repository
 
     def parse_month_range(self, month_range: str) -> List[str]:
-        """Parse month range string into list of months"""
+        """Parse month range string into list of months."""
         parts = month_range.split(":")
         if len(parts) != 2:
             raise ValueError("Invalid month range format")
@@ -42,11 +28,10 @@ class ForecastService:
         if start_date > end_date:
             raise ValueError("Start month must be before end month")
 
-        months = []
+        months: List[str] = []
         current = start_date
         while current <= end_date:
             months.append(current.strftime("%Y-%m"))
-            # Move to next month
             if current.month == 12:
                 current = current.replace(year=current.year + 1, month=1)
             else:
@@ -55,19 +40,16 @@ class ForecastService:
         return months
 
     def get_forecasts(self, query: ForecastQuery) -> List[GridCellForecast]:
-        """Get forecasts based on query parameters"""
-        # Process month filters
+        """Get forecasts based on query parameters."""
         months_filter = query.months
 
         if query.month_range:
             range_months = self.parse_month_range(query.month_range)
             if months_filter:
-                # Combine both filters
                 months_filter = list(set(months_filter) | set(range_months))
             else:
                 months_filter = range_months
 
-        # Get forecasts from data loader
         metrics_filter = None
         if query.metrics:
             metrics_filter = [
@@ -75,18 +57,18 @@ class ForecastService:
                 for metric in query.metrics
             ]
 
-        forecasts = self.data_loader.get_forecasts(
+        forecasts = self.repository.get_forecasts(
             country=query.country,
             grid_ids=query.grid_ids,
             months=months_filter,
             metrics=metrics_filter,
         )
 
-        logger.info(f"Retrieved {len(forecasts)} forecasts")
+        logger.info("Retrieved %d forecasts", len(forecasts))
         return forecasts
 
     def get_forecast_summary(self, forecasts: List[GridCellForecast]) -> Dict[str, Any]:
-        """Generate summary statistics for forecasts"""
+        """Generate summary statistics for forecasts."""
         if not forecasts:
             return {
                 "count": 0,
@@ -100,7 +82,7 @@ class ForecastService:
         months = set()
         grid_cells = set()
 
-        total_map = 0
+        total_map = 0.0
         min_map = float("inf")
         max_map = float("-inf")
 
@@ -114,7 +96,7 @@ class ForecastService:
                 min_map = min(min_map, forecast.metrics.map)
                 max_map = max(max_map, forecast.metrics.map)
 
-        avg_map = total_map / len(forecasts) if forecasts else 0
+        avg_map = total_map / len(forecasts) if forecasts else 0.0
 
         return {
             "count": len(forecasts),
@@ -131,15 +113,7 @@ class ForecastService:
     def filter_metrics(
         self, forecast: GridCellForecast, metrics: List[MetricName]
     ) -> Dict[str, Any]:
-        """Filter forecast to include only requested metrics.
-
-        Args:
-            forecast: Complete forecast data for a grid cell.
-            metrics: List of metric names to include in the output.
-
-        Returns:
-            Dictionary containing forecast data with only requested metrics.
-        """
+        """Filter forecast to include only requested metrics."""
         result = {
             "grid_id": forecast.grid_id,
             "latitude": forecast.latitude,
@@ -153,13 +127,11 @@ class ForecastService:
         if forecast.admin_2_id:
             result["admin_2_id"] = forecast.admin_2_id
 
-        # Add only requested metrics
         metrics_dict = forecast.metrics.model_dump()
         allowed = {metric.value if isinstance(metric, MetricName) else metric for metric in metrics}
-        result["metrics"] = {k: v for k, v in metrics_dict.items() if k in allowed}
+        result["metrics"] = {name: value for name, value in metrics_dict.items() if name in allowed}
 
         return result
 
 
-# Singleton instance
-forecast_service = ForecastService()
+__all__ = ["ForecastService"]

--- a/app/services/sample_data.py
+++ b/app/services/sample_data.py
@@ -82,7 +82,7 @@ class SampleConfig:
 
     # Default UN M49 numeric country codes (zero-padded to 3 digits)
     countries: Sequence[str] = ("074", "108", "404", "454", "800", "834")
-    months: Iterable[str] = tuple(pd.period_range("2024-01", periods=6, freq="M").astype(str))
+    months: Iterable[str] = tuple(pd.period_range("2025-08", periods=12, freq="M").astype(str))
     grids_per_country: int = 6
     seed: int = 1337
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -173,3 +173,9 @@ def test_invalid_metrics():
     """Test validation of invalid metrics"""
     response = client.get("/api/v1/forecasts?metrics=invalid_metric")
     assert response.status_code == 422
+
+
+def test_invalid_metric_filter():
+    """Metric filter expressions should be validated."""
+    response = client.get("/api/v1/forecasts?metric_filters=map>>50")
+    assert response.status_code == 400

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2,72 +2,64 @@ import pytest
 
 from app.core.config import settings
 from app.models.forecast import ForecastQuery, MetricName
-from app.services.data_loader import DataLoader
+from app.services.data_loader import ParquetForecastRepository
 from app.services.forecast_service import ForecastService
 
 
-def test_parse_month_range():
-    """Test month range parsing"""
-    service = ForecastService()
+@pytest.fixture()
+def repository(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "data_path", str(tmp_path), raising=False)
+    return ParquetForecastRepository()
 
-    # Test simple range
+
+@pytest.fixture()
+def service(repository):
+    return ForecastService(repository)
+
+
+def test_parse_month_range(service):
+    """Test month range parsing."""
+
     months = service.parse_month_range("2024-01:2024-03")
     assert months == ["2024-01", "2024-02", "2024-03"]
 
-    # Test year boundary
     months = service.parse_month_range("2023-11:2024-02")
     assert months == ["2023-11", "2023-12", "2024-01", "2024-02"]
 
-    # Test single month
     months = service.parse_month_range("2024-06:2024-06")
     assert months == ["2024-06"]
 
-    # Test invalid range (start > end)
     with pytest.raises(ValueError):
         service.parse_month_range("2024-03:2024-01")
 
-    # Test invalid format
     with pytest.raises(ValueError):
         service.parse_month_range("2024-01-2024-03")
 
 
-def test_get_forecasts():
-    """Test getting forecasts"""
-    service = ForecastService()
-
-    # Test basic query
-    query = ForecastQuery()
-    forecasts = service.get_forecasts(query)
+def test_get_forecasts(service):
+    """Test getting forecasts."""
+    forecasts = service.get_forecasts(ForecastQuery())
     assert isinstance(forecasts, list)
 
-    # Test with country filter
     query = ForecastQuery(country="800")
     forecasts = service.get_forecasts(query)
     for forecast in forecasts:
         assert forecast.country_id == "800"
 
-    # Test with month range
     query = ForecastQuery(month_range="2024-01:2024-02")
     forecasts = service.get_forecasts(query)
     for forecast in forecasts:
         assert forecast.month in ["2024-01", "2024-02"]
 
-    # Test with metric filter
     query = ForecastQuery(metrics=[MetricName.map, MetricName.prob_10])
     forecasts = service.get_forecasts(query)
     for forecast in forecasts:
         assert set(forecast.metrics.model_dump().keys()) == {"map", "prob_10"}
 
 
-def test_get_forecast_summary():
-    """Test forecast summary generation"""
-    service = ForecastService()
-
-    # Get some forecasts
-    query = ForecastQuery()
-    forecasts = service.get_forecasts(query)
-
-    # Generate summary
+def test_get_forecast_summary(service):
+    """Test forecast summary generation."""
+    forecasts = service.get_forecasts(ForecastQuery())
     summary = service.get_forecast_summary(forecasts)
 
     assert "count" in summary
@@ -83,33 +75,12 @@ def test_get_forecast_summary():
         assert summary["grid_cells"] > 0
 
 
-def test_data_loader_falls_back_when_credentials_missing(monkeypatch, tmp_path):
-    """Cloud backend should fall back to sample data if AWS credentials are blank."""
-
-    monkeypatch.setattr(settings, "data_backend", "cloud", raising=False)
-    monkeypatch.setattr(settings, "use_local_data", False, raising=False)
-    monkeypatch.setattr(settings, "aws_access_key_id", "", raising=False)
-    monkeypatch.setattr(settings, "aws_secret_access_key", "", raising=False)
+def test_repository_generates_sample_data(monkeypatch, tmp_path):
+    """Repository should generate sample data when none exists."""
     monkeypatch.setattr(settings, "data_path", str(tmp_path), raising=False)
 
-    loader = DataLoader()
+    repository = ParquetForecastRepository()
+    forecasts = repository.get_forecasts()
 
-    assert loader.backend == "parquet"
+    assert forecasts, "Sample data should provide forecast rows"
     assert (tmp_path / "sample_data.parquet").exists()
-    assert loader.get_forecasts(), "Sample data should provide forecast rows"
-
-
-def test_data_loader_falls_back_when_use_local_data(monkeypatch, tmp_path):
-    """USE_LOCAL_DATA=true should force sample data usage even for cloud backend."""
-
-    monkeypatch.setattr(settings, "data_backend", "cloud", raising=False)
-    monkeypatch.setattr(settings, "use_local_data", True, raising=False)
-    monkeypatch.setattr(settings, "aws_access_key_id", "key", raising=False)
-    monkeypatch.setattr(settings, "aws_secret_access_key", "secret", raising=False)
-    monkeypatch.setattr(settings, "data_path", str(tmp_path), raising=False)
-
-    loader = DataLoader()
-
-    assert loader.backend == "parquet"
-    assert (tmp_path / "sample_data.parquet").exists()
-    assert loader.get_forecasts(), "Sample data should provide forecast rows"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,15 +1,90 @@
+import pandas as pd
 import pytest
 
 from app.core.config import settings
 from app.models.forecast import ForecastQuery, MetricName
 from app.services.data_loader import ParquetForecastRepository
 from app.services.forecast_service import ForecastService
+from app.services.sample_data import FORECAST_COLUMNS
 
 
 @pytest.fixture()
 def repository(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "data_path", str(tmp_path), raising=False)
-    return ParquetForecastRepository()
+    data = [
+        {
+            "grid_id": 1,
+            "latitude": 11.1,
+            "longitude": 14.4,
+            "country_id": "074",
+            "admin_1_id": "074-ADM1-00",
+            "admin_2_id": "074-ADM2-00",
+            "month": "2024-01",
+            "map": 60.0,
+            "ci_50_low": 45.0,
+            "ci_50_high": 75.0,
+            "ci_90_low": 30.0,
+            "ci_90_high": 90.0,
+            "ci_99_low": 25.0,
+            "ci_99_high": 105.0,
+            "prob_0": 0.1,
+            "prob_1": 0.9,
+            "prob_10": 0.5,
+            "prob_100": 0.2,
+            "prob_1000": 0.15,
+            "prob_10000": 0.05,
+        },
+        {
+            "grid_id": 1,
+            "latitude": 11.1,
+            "longitude": 14.4,
+            "country_id": "074",
+            "admin_1_id": "074-ADM1-00",
+            "admin_2_id": "074-ADM2-00",
+            "month": "2024-02",
+            "map": 40.0,
+            "ci_50_low": 30.0,
+            "ci_50_high": 50.0,
+            "ci_90_low": 20.0,
+            "ci_90_high": 60.0,
+            "ci_99_low": 15.0,
+            "ci_99_high": 70.0,
+            "prob_0": 0.2,
+            "prob_1": 0.8,
+            "prob_10": 0.3,
+            "prob_100": 0.1,
+            "prob_1000": 0.05,
+            "prob_10000": 0.01,
+        },
+        {
+            "grid_id": 2,
+            "latitude": -1.2,
+            "longitude": 32.5,
+            "country_id": "800",
+            "admin_1_id": "800-ADM1-00",
+            "admin_2_id": "800-ADM2-00",
+            "month": "2024-01",
+            "map": 15.0,
+            "ci_50_low": 10.0,
+            "ci_50_high": 20.0,
+            "ci_90_low": 5.0,
+            "ci_90_high": 25.0,
+            "ci_99_low": 2.0,
+            "ci_99_high": 30.0,
+            "prob_0": 0.4,
+            "prob_1": 0.6,
+            "prob_10": 0.2,
+            "prob_100": 0.05,
+            "prob_1000": 0.01,
+            "prob_10000": 0.0,
+        },
+    ]
+
+    df = pd.DataFrame(data, columns=FORECAST_COLUMNS)
+    parquet_path = tmp_path / "forecasts.parquet"
+    df.to_parquet(parquet_path, index=False)
+
+    return ParquetForecastRepository(data_path=str(tmp_path))
 
 
 @pytest.fixture()
@@ -84,3 +159,17 @@ def test_repository_generates_sample_data(monkeypatch, tmp_path):
 
     assert forecasts, "Sample data should provide forecast rows"
     assert (tmp_path / "sample_data.parquet").exists()
+
+
+def test_metric_filters(service):
+    query = ForecastQuery(metric_filters=["map>50"], metrics=[MetricName.map])
+    forecasts = service.get_forecasts(query)
+    assert len(forecasts) == 1
+    assert forecasts[0].metrics.map > 50
+
+    query = ForecastQuery(metric_filters=["prob_1000>=0.1"])
+    forecasts = service.get_forecasts(query)
+    assert {f.grid_id for f in forecasts} == {1}
+
+    with pytest.raises(ValueError):
+        service.get_forecasts(ForecastQuery(metric_filters=["map>>50"]))

--- a/views-forecast-api-bruno/Forecasts - By Country.bru
+++ b/views-forecast-api-bruno/Forecasts - By Country.bru
@@ -5,13 +5,22 @@ meta {
 }
 
 get {
-  url: http://localhost:8000/api/v1/forecasts?country=074
+  url: http://localhost:8000/api/v1/forecasts?country=074&metrics=map&metrics=ci_50_low&metrics=ci_50_high&metrics=ci_90_low&metrics=ci_90_high&metrics=ci_99_low&metrics=ci_99_high&metrics=prob_100&metrics=prob_1000
   body: none
   auth: apikey
 }
 
 params:query {
   country: 074
+  metrics: map
+  metrics: ci_50_low
+  metrics: ci_50_high
+  metrics: ci_90_low
+  metrics: ci_90_high
+  metrics: ci_99_low
+  metrics: ci_99_high
+  metrics: prob_100
+  metrics: prob_1000
 }
 
 auth:apikey {

--- a/views-forecast-api-bruno/Months.bru
+++ b/views-forecast-api-bruno/Months.bru
@@ -12,7 +12,7 @@ get {
 
 auth:apikey {
   key: X-API-Key
-  value: optional-api-key-for-production
+  value: your-local-api-key
   placement: header
 }
 


### PR DESCRIPTION

*Add  a new `ForecastRepository` protocol in `app/domain/repositories.py` to abstract data access for forecasts, months, and grid cells, allowing the application to depend on interfaces rather than concrete implementations.
* add a new dependency wiring module `app/di.py` that provides `get_forecast_repository` and `get_forecast_service` functions for injecting dependencies into FastAPI routes.
